### PR TITLE
Use nonblocking writes to avoid timeout thread and interrupts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ them. You can see some examples of how to use this gem in the
 [`./examples`](./examples) directory.
 
 - [`./examples/wasm_opt.rb`](./examples/wasm_opt.rb) - Optimize a WebAssembly module
-- [`./examples/wasm_strip.rb`](./examples/wasm_strip.rb) - Strip a WebAssembly module
+- [`./examples/wasm_split.rb`](./examples/wasm_split.rb) - Strip a WebAssembly module
 
 ## Contributing
 

--- a/examples/wasm_opt.rb
+++ b/examples/wasm_opt.rb
@@ -19,4 +19,4 @@ wasm_code = <<~WASM
 WASM
 
 wasm_opt = Binaryen::Command.new("wasm-opt", timeout: 2)
-puts(wasm_opt.run("--emit-text", "-O4", "--debug", stdin: wasm_code, stderr: $stderr).read)
+puts(wasm_opt.run("--emit-text", "-O4", "--debug", stdin: wasm_code, stderr: $stderr))

--- a/examples/wasm_split.rb
+++ b/examples/wasm_split.rb
@@ -19,5 +19,4 @@ WASM
 
 wasm_split = Binaryen::Command.new("wasm-split", timeout: 2)
 result = wasm_split.run("-", stdin: wasm_code, stderr: $stderr)
-puts(result.read)
-# exit(result.read.start_with?("\x00asm"))
+puts(result)

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -97,7 +97,7 @@ module Binaryen
         missing_command.run("dfasdfasdfasdfsadf")
       end
 
-      assert_match(/^command exited with status 1:/, err.message)
+      assert_match(/^command exited with status 1/, err.message)
     end
 
     def test_it_can_redirect_stderr

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -9,7 +9,7 @@ module Binaryen
       version_number = Binaryen::BINARYEN_VERSION.split("_").last
       result = wasm_opt.run("--version")
 
-      assert_match(/wasm-opt version #{version_number}/, result.read.strip)
+      assert_match(/wasm-opt version #{version_number}/, result.strip)
     end
 
     def test_it_accepts_stdin
@@ -17,14 +17,76 @@ module Binaryen
       result = wasm_opt.run("-O4", stdin: "(module)")
       expected = "\x00asm"
 
-      assert(result.read.start_with?(expected), "Expected #{result.read.inspect} to start with #{expected.inspect}")
+      assert(result.start_with?(expected), "Expected #{result.inspect} to start with #{expected.inspect}")
     end
 
-    def test_times_out_sanely
-      sleep_command = Binaryen::Command.new("sleep", timeout: 0.1, ignore_missing: true)
+    def test_times_out_sanely_on_no_output
+      attempts = 5
 
-      assert_raises(Timeout::Error) do
-        sleep_command.run("5")
+      begin
+        timeout = 0.1
+        sleep_command = Binaryen::Command.new("sleep", timeout: 0.1, ignore_missing: true)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        assert_raises(Timeout::Error) do
+          sleep_command.run("5")
+        end
+        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        duration = end_time - start_time
+        error_margin = timeout * 1.10
+
+        assert(duration >= timeout, "should not time out early")
+        assert(duration < error_margin, "timeout took too long")
+      rescue Minitest::Assertion
+        attempts -= 1
+        retry if attempts > 0
+        raise
+      end
+    end
+
+    def test_times_out_sanely_on_reads
+      attempts = 5
+
+      begin
+        timeout = 0.1
+        yes_command = Binaryen::Command.new("yes", timeout: 0.1, ignore_missing: true)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        assert_raises(Timeout::Error) do
+          yes_command.run
+        end
+        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        duration = end_time - start_time
+        error_margin = timeout * 1.10
+
+        assert(duration >= timeout, "should not time out early")
+        assert(duration < error_margin, "timeout took too long")
+      rescue Minitest::Assertion
+        attempts -= 1
+        retry if attempts > 0
+        raise
+      end
+    end
+
+    def test_times_out_sanely_on_blocking_writes
+      attempts = 5
+      stdin =  "y" * (64 * 1024 * 1024)
+
+      begin
+        timeout = 0.1
+        slow_command = Binaryen::Command.new("ruby", ignore_missing: true, timeout: timeout)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        assert_raises(Timeout::Error) do
+          slow_command.run("-e", "while STDIN.getc; sleep 0.01; end", stdin: stdin)
+        end
+        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        duration = end_time - start_time
+        error_margin = timeout * 1.10
+
+        assert(duration >= timeout, "should not time out early")
+        assert(duration < error_margin, "timeout took too long")
+      rescue Minitest::Assertion
+        attempts -= 1
+        retry if attempts > 0
+        raise
       end
     end
 

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -21,73 +21,16 @@ module Binaryen
     end
 
     def test_times_out_sanely_on_no_output
-      attempts = 5
-
-      begin
-        timeout = 0.1
-        sleep_command = Binaryen::Command.new("sleep", timeout: 0.1, ignore_missing: true)
-        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        assert_raises(Timeout::Error) do
-          sleep_command.run("5")
-        end
-        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        duration = end_time - start_time
-        error_margin = timeout * 1.10
-
-        assert(duration >= timeout, "should not time out early")
-        assert(duration < error_margin, "timeout took too long")
-      rescue Minitest::Assertion
-        attempts -= 1
-        retry if attempts > 0
-        raise
-      end
+      assert_proper_timeout_for_command("sleep", "5")
     end
 
     def test_times_out_sanely_on_reads
-      attempts = 5
-
-      begin
-        timeout = 0.1
-        yes_command = Binaryen::Command.new("yes", timeout: 0.1, ignore_missing: true)
-        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        assert_raises(Timeout::Error) do
-          yes_command.run
-        end
-        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        duration = end_time - start_time
-        error_margin = timeout * 1.10
-
-        assert(duration >= timeout, "should not time out early")
-        assert(duration < error_margin, "timeout took too long")
-      rescue Minitest::Assertion
-        attempts -= 1
-        retry if attempts > 0
-        raise
-      end
+      assert_proper_timeout_for_command("yes")
     end
 
     def test_times_out_sanely_on_blocking_writes
-      attempts = 5
-      stdin =  "y" * (64 * 1024 * 1024)
-
-      begin
-        timeout = 0.1
-        slow_command = Binaryen::Command.new("ruby", ignore_missing: true, timeout: timeout)
-        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        assert_raises(Timeout::Error) do
-          slow_command.run("-e", "while STDIN.getc; sleep 0.01; end", stdin: stdin)
-        end
-        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        duration = end_time - start_time
-        error_margin = timeout * 1.10
-
-        assert(duration >= timeout, "should not time out early")
-        assert(duration < error_margin, "timeout took too long")
-      rescue Minitest::Assertion
-        attempts -= 1
-        retry if attempts > 0
-        raise
-      end
+      stdin = "y" * (64 * 1024 * 1024)
+      assert_proper_timeout_for_command("ruby", "-e", "while STDIN.getc; sleep 0.01; end", stdin: stdin)
     end
 
     def test_it_raises_an_error_with_a_reasonable_message_if_the_command_is_not_found
@@ -113,6 +56,31 @@ module Binaryen
     ensure
       stderr.close
       stderr.unlink
+    end
+
+    private
+
+    def assert_proper_timeout_for_command(command, *args, stdin: nil)
+      attempts = 10
+      timeout = 0.1
+      error_margin = timeout * 1.25
+
+      begin
+        command_instance = Binaryen::Command.new(command, timeout: timeout, ignore_missing: true)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        assert_raises(Timeout::Error) do
+          command_instance.run(*args, stdin: stdin)
+        end
+        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        duration = end_time - start_time
+
+        assert(duration >= timeout, "should not time out early")
+        assert(duration < error_margin, "timeout took too long")
+      rescue Minitest::Assertion
+        attempts -= 1
+        retry if attempts > 0
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
The old implementation would block on large amounts of data, and in general was annoying to work with since it returned an IO. This PR fixes those issues, and implements non-blocking command execution without relying on `Timeout.timeout` based interrupts.