### PR TITLE
Output results to a file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby: ["2.7", "ruby-head"]
+        ruby: ["2.7", "3.3"]
         os: ["ubuntu-latest", "macos-latest"]
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:

--- a/examples/wasm_split.rb
+++ b/examples/wasm_split.rb
@@ -2,21 +2,22 @@
 
 require "binaryen"
 
-wasm_code = <<~WASM
-  (module
-    (func $one (result i32)
-      (i32.const 1)
-    )
+# TODO: Need to figure out --output argument here
+# wasm_code = <<~WASM
+#   (module
+#     (func $one (result i32)
+#       (i32.const 1)
+#     )
 
-    (func $two (result i32)
-      (i32.const 2)
-    )
+#     (func $two (result i32)
+#       (i32.const 2)
+#     )
 
-    (export "one" (func $one))
-    (export "two" (func $two))
-  )
-WASM
-
-wasm_split = Binaryen::Command.new("wasm-split", timeout: 2)
-result = wasm_split.run(stdin: wasm_code, stderr: $stderr)
-puts(result)
+#     (export "one" (func $one))
+#     (export "two" (func $two))
+#   )
+# WASM
+#
+# wasm_split = Binaryen::Command.new("wasm-split", timeout: 2)
+# result = wasm_split.run(stdin: wasm_code, stderr: $stderr)
+# puts(result)

--- a/lib/binaryen/error.rb
+++ b/lib/binaryen/error.rb
@@ -4,4 +4,5 @@ module Binaryen
   class Error < StandardError; end
   class NonZeroExitStatus < Error; end
   class MaximumOutputExceeded < Error; end
+  class Signal < Error; end
 end


### PR DESCRIPTION
The old code relied on pipes to capture output. This worked most of the time, but there was a race condition which would cause for invalid reads if we read from the pipe too early. To avoid this annoying race condition, we buffer output to a file instead.