### PR TITLE
Drop dependency on posix-spawn

### DIFF
--- a/binaryen.gemspec
+++ b/binaryen.gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Shopify/binaryen-rb"
   spec.platform = Gem::Platform::RUBY
   spec.extensions = ["extconf.rb"]
-  spec.add_dependency("posix-spawn", "~> 0.3.15")
 end

--- a/lib/binaryen/command.rb
+++ b/lib/binaryen/command.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "posix/spawn"
 require "timeout"
 require "tempfile"
 
 module Binaryen
   class Command
-    include POSIX::Spawn
     DEFAULT_MAX_OUTPUT_SIZE = 256 * 1024 * 1024 * 1024 # 256 MiB
     DEFAULT_TIMEOUT = 10
     DEFAULT_ARGS_FOR_COMMAND = {}.freeze
@@ -44,7 +42,7 @@ module Binaryen
 
           File.open(File::NULL, "w") do |devnull|
             IO.pipe do |err_read, err_write|
-              pid = POSIX::Spawn.pspawn(
+              pid = Process.spawn(
                 *args,
                 "--output=#{tmpfile.path}",
                 in_write.path,


### PR DESCRIPTION
This gem no longer build on the latest clang version:

```
posix-spawn.c:226:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, posix_spawn_file_actions_t *)' (aka 'int (unsigned long, unsigned long, void **)') to parameter of type 'int
(*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
        rb_hash_foreach(options, posixspawn_file_actions_operations_iter, (VALUE)fops);
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rubies/3.4-dev-03-19/include/ruby-3.4.0+0/ruby/internal/intern/hash.h:83:40: note: passing argument to parameter 'func' here
void rb_hash_foreach(VALUE hash, int (*func)(VALUE key, VALUE val, VALUE arg), VALUE arg);
```

It's also unnecessary given Ruby's `Process.spawn` use `vfork(2)` so it's essentially the same as `posix-spawn`. The only difference is that Ruby fallback to using `fork(2)` when running as root, but that's not something that should be common. Other than that there is no perf gain to use `posix-spawn` gem.